### PR TITLE
feat: converting Beacon->Taquito for all types in ParamsWithKind

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
+};

--- a/src/convert_beacon_to_taquito.ts
+++ b/src/convert_beacon_to_taquito.ts
@@ -1,0 +1,139 @@
+import { OpKind } from "@taquito/taquito";
+import { TezosOperationType } from "./beacon_types";
+import { PartialTezosOperation } from "./operations";
+import { PartialParamsWithKind } from "./taquito_types";
+
+export function convertToPartialParamsWithKind (op: PartialTezosOperation): PartialParamsWithKind {
+  switch (op.kind) {
+    case TezosOperationType.ACTIVATE_ACCOUNT:
+      return {
+        kind: OpKind.ACTIVATION,
+        pkh: op.pkh,
+        secret: op.secret,
+      };
+    case TezosOperationType.DELEGATION:
+      return {
+        kind: OpKind.DELEGATION,
+        source: op.source ? op.source : undefined,
+        delegate: op.delegate,
+        fee: op.fee ? Number(op.fee) : undefined,
+        gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+        storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+      };
+    case TezosOperationType.FAILING_NOOP:
+      return {
+        kind: OpKind.FAILING_NOOP,
+        arbitrary: op.arbitrary,
+        basedOnBlock: 'head' 
+      };
+    case TezosOperationType.INCREASE_PAID_STORAGE:
+      return {
+        kind: OpKind.INCREASE_PAID_STORAGE,
+        source: op.source,
+        fee: op.fee ? Number(op.fee) : undefined,
+        gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+        storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+        amount: Number(op.amount),
+        destination: op.destination
+      };
+    case TezosOperationType.INCREASE_PAID_STORAGE:
+      return {
+        kind: OpKind.INCREASE_PAID_STORAGE,
+        source: op.source,
+        fee: op.fee ? Number(op.fee) : undefined,
+        gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+        storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+        amount: Number(op.amount),
+        destination: op.destination,
+      };
+      case TezosOperationType.ORIGINATION:
+        return {
+          kind: OpKind.ORIGINATION,
+          balance: Number(op.balance),
+          code: op.script.code,
+          init: op.script.storage,
+          delegate: op.delegate,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined
+        };
+      case TezosOperationType.REGISTER_GLOBAL_CONSTANT:
+        return {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          value: op.value
+        };
+      case TezosOperationType.SMART_ROLLUP_ADD_MESSAGES:
+        return {
+          kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          message: op.message
+        };
+      case TezosOperationType.SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE:
+        return {
+          kind: OpKind.SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          rollup: op.rollup,
+          cementedCommitment: op.cemented_commitment,
+          outputProof: op.output_proof,
+        };
+      case TezosOperationType.SMART_ROLLUP_ORIGINATE:
+        return {
+          kind: OpKind.SMART_ROLLUP_ORIGINATE,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          pvmKind: op.pvm_kind,
+          kernel: op.kernel,
+          parametersType: op.parameters_ty,
+        };
+      case TezosOperationType.TRANSACTION:
+        return {
+          kind: OpKind.TRANSACTION,
+          to: op.destination,
+          amount: Number(op.amount),
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          parameter: op.parameters,
+        };
+      case TezosOperationType.TRANSFER_TICKET:
+        return {
+          kind: OpKind.TRANSFER_TICKET,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          ticketContents: op.ticket_contents,
+          ticketTy: op.ticket_ty,
+          ticketTicketer: op.ticket_ticketer,
+          ticketAmount: Number(op.ticket_amount),
+          destination: op.destination,
+          entrypoint: op.entrypoint
+        };
+      case TezosOperationType.UPDATE_CONSENSUS_KEY:
+        return {
+          kind: OpKind.UPDATE_CONSENSUS_KEY,
+          source: op.source,
+          fee: op.fee ? Number(op.fee) : undefined,
+          gasLimit: op.gas_limit ? Number(op.gas_limit) : undefined,
+          storageLimit: op.storage_limit ? Number(op.storage_limit) : undefined,
+          pk: op.pk
+        };
+
+      default:
+        throw new Error(`Unsupported operation kind: ${op.kind}`);
+    }
+};
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./common";
 export * from "./operations";
 export * from "./beacon_types";
+export * from "./taquito_types";
+export * from "./convert_beacon_to_taquito";

--- a/src/taquito_types.ts
+++ b/src/taquito_types.ts
@@ -1,0 +1,31 @@
+import { SmartRollupExecuteOutboxMessageParams } from "@taquito/taquito/dist/types/operations/types";
+import { Optional } from "./beacon_types";
+import {
+    ActivationParams,
+    DelegateParams,
+    FailingNoopParams,
+    IncreasePaidStorageParams,
+    OpKind,
+    OriginateParams,
+    RegisterGlobalConstantParams,
+    SmartRollupAddMessagesParams,
+    SmartRollupOriginateParams,
+    TransferParams,
+    TransferTicketParams,
+    UpdateConsensusKeyParams,
+    withKind
+} from "@taquito/taquito";
+
+export type PartialParamsWithKind =
+| withKind<OriginateParams, OpKind.ORIGINATION>
+| withKind<Optional<DelegateParams, 'source'>, OpKind.DELEGATION>
+| withKind<TransferParams, OpKind.TRANSACTION>
+| withKind<ActivationParams, OpKind.ACTIVATION>
+| withKind<RegisterGlobalConstantParams, OpKind.REGISTER_GLOBAL_CONSTANT>
+| withKind<IncreasePaidStorageParams, OpKind.INCREASE_PAID_STORAGE>
+| withKind<TransferTicketParams, OpKind.TRANSFER_TICKET>
+| withKind<UpdateConsensusKeyParams, OpKind.UPDATE_CONSENSUS_KEY>
+| withKind<SmartRollupAddMessagesParams, OpKind.SMART_ROLLUP_ADD_MESSAGES>
+| withKind<FailingNoopParams, OpKind.FAILING_NOOP>
+| withKind<SmartRollupOriginateParams, OpKind.SMART_ROLLUP_ORIGINATE>
+| withKind<SmartRollupExecuteOutboxMessageParams, OpKind.SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE>;

--- a/test/unit/convertToPartialParamsWithKind.test.ts
+++ b/test/unit/convertToPartialParamsWithKind.test.ts
@@ -1,0 +1,374 @@
+import { OpKind } from "@taquito/taquito";
+import {
+  PartialTezosDelegationOperation,
+  PartialTezosTransactionOperation,
+  TezosOperationType,
+  PartialTezosRegisterGlobalConstantOperation,
+  PartialTezosSmartRollupAddMessagesOperation,
+  PartialTezosSmartRollupExecuteOutboxMessageOperation,
+  PartialTezosSmartRollupOriginateOperation,
+  PartialTezosTransferTicketOperation,
+  PartialTezosUpdateConsensusKeyOperation,
+} from "../../src/beacon_types";
+import { PartialTezosOriginationOperation } from "../../src/operations";
+import { convertToPartialParamsWithKind } from "../../src/convert_beacon_to_taquito";
+import { PartialParamsWithKind } from "../../src/taquito_types";
+import { PvmKind } from "@taquito/rpc";
+
+
+describe("convertToPartialParamsWithKind", () => {
+  it("should convert ORIGINATION operation correctly", () => {
+    const originationOp: PartialTezosOriginationOperation = {
+      kind: TezosOperationType.ORIGINATION,
+      balance: "1000000",
+      script: { code: [], storage: [] },
+      delegate: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+    };
+
+    const result = convertToPartialParamsWithKind(originationOp);
+
+    expect(result).toEqual({
+      kind: OpKind.ORIGINATION,
+      balance: 1000000,
+      code: [],
+      init: [],
+      delegate: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+    });
+  });
+
+  it("should convert DELEGATION operation correctly", () => {
+    const delegationOp: PartialTezosDelegationOperation = {
+      kind: TezosOperationType.DELEGATION,
+      source: "tz1VSU...Yt8G",
+      delegate: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(delegationOp);
+
+    expect(result).toEqual({
+      kind: OpKind.DELEGATION,
+      source: "tz1VSU...Yt8G",
+      delegate: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+    });
+  });
+
+  it("should convert TRANSACTION operation correctly", () => {
+    const transactionOp: PartialTezosTransactionOperation = {
+      kind: TezosOperationType.TRANSACTION,
+      destination: "tz1VSU...Yt8G",
+      amount: "1000000",
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      parameters: { entrypoint: "default", value: [] },
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(transactionOp);
+
+    expect(result).toEqual({
+      kind: OpKind.TRANSACTION,
+      to: "tz1VSU...Yt8G",
+      amount: 1000000,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      parameter: { entrypoint: "default", value: [] },
+    });
+  });
+
+  it("should handle partial TRANSACTION operation", () => {
+    const tezosTransactionOperation: PartialTezosTransactionOperation = {
+      kind: TezosOperationType.TRANSACTION,
+      destination: "tz1VSU...Yt8G",
+      amount: "100",
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(tezosTransactionOperation);
+
+    expect(result).toEqual({
+      kind: OpKind.TRANSACTION,
+      amount: 100,
+      fee: undefined,
+      gasLimit: undefined,
+      parameter: undefined,
+      source: undefined,
+      storageLimit: undefined,
+      to: "tz1VSU...Yt8G",
+    });
+  });
+
+  it("should handle ORIGINATION operation with complex script", () => {
+    const tezosOriginationOperation: PartialTezosOriginationOperation = {
+      kind: TezosOperationType.ORIGINATION,
+      balance: "1",
+      script: {
+        code: [
+          { prim: "parameter", args: [{ prim: "unit" }] },
+          { prim: "storage", args: [{ prim: "int" }] },
+          {
+            prim: "code",
+            args: [
+              [
+                { prim: "CDR" },
+                { prim: "PUSH", args: [{ prim: "int" }, { int: "10" }] },
+                { prim: "ADD" },
+                { prim: "NIL", args: [{ prim: "operation" }] },
+                { prim: "PAIR" },
+              ],
+            ],
+          },
+        ],
+        storage: { int: "0" },
+      },
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(tezosOriginationOperation);
+
+    expect(result).toEqual({
+      balance: 1,
+      code: [
+        { prim: "parameter", args: [{ prim: "unit" }] },
+        { prim: "storage", args: [{ prim: "int" }] },
+        {
+          prim: "code",
+          args: [
+            [
+              { prim: "CDR" },
+              { prim: "PUSH", args: [{ prim: "int" }, { int: "10" }] },
+              { prim: "ADD" },
+              { prim: "NIL", args: [{ prim: "operation" }] },
+              { prim: "PAIR" },
+            ],
+          ],
+        },
+      ],
+      delegate: undefined,
+      fee: undefined,
+      gasLimit: undefined,
+      init: { int: "0" },
+      kind: OpKind.ORIGINATION,
+      storageLimit: undefined,
+    });
+  });
+
+  it("should handle contract call TRANSACTION operation", () => {
+    const tezosContractCallOperation: PartialTezosTransactionOperation = {
+      kind: TezosOperationType.TRANSACTION,
+      destination: "$(contractAddress)",
+      amount: "0",
+      parameters: { entrypoint: "default", value: { prim: "Unit" } },
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(tezosContractCallOperation);
+
+    expect(result).toEqual({
+      amount: 0,
+      fee: undefined,
+      gasLimit: undefined,
+      kind: OpKind.TRANSACTION,
+      parameter: { entrypoint: "default", value: { prim: "Unit" } },
+      source: undefined,
+      storageLimit: undefined,
+      to: "$(contractAddress)",
+    });
+  });
+
+  it("should handle DELEGATION operation", () => {
+    const tezosDelegationOperation: PartialTezosDelegationOperation = {
+      kind: TezosOperationType.DELEGATION,
+      delegate: "tz3ZmB8oWUmi8YZXgeRpgAcPnEMD8VgUa4Ve", // Tezos Foundation Ghost Baker
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(tezosDelegationOperation);
+
+    expect(result).toEqual({
+      delegate: "tz3ZmB8oWUmi8YZXgeRpgAcPnEMD8VgUa4Ve",
+      fee: undefined,
+      gasLimit: undefined,
+      kind: OpKind.DELEGATION,
+      source: undefined,
+      storageLimit: undefined,
+    });
+  });
+
+  it("should handle undelegation operation", () => {
+    const tezosUndelegationOperation: PartialTezosDelegationOperation = {
+      kind: TezosOperationType.DELEGATION,
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(tezosUndelegationOperation);
+
+    expect(result).toEqual({
+      delegate: undefined,
+      fee: undefined,
+      gasLimit: undefined,
+      kind: OpKind.DELEGATION,
+      source: undefined,
+      storageLimit: undefined,
+    });
+  });
+    
+  it("should convert REGISTER_GLOBAL_CONSTANT operation correctly", () => {
+    const registerGlobalConstantOp: PartialTezosRegisterGlobalConstantOperation = {
+      kind: TezosOperationType.REGISTER_GLOBAL_CONSTANT,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      value: { prim: "Pair", args: [] },
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(registerGlobalConstantOp);
+
+    expect(result).toEqual({
+      kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      value: { prim: "Pair", args: [] },
+    });
+  });
+
+  it("should convert SMART_ROLLUP_ADD_MESSAGES operation correctly", () => {
+    const smartRollupAddMessagesOp: PartialTezosSmartRollupAddMessagesOperation = {
+      kind: TezosOperationType.SMART_ROLLUP_ADD_MESSAGES,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      message: ["message1", "message2"],
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(smartRollupAddMessagesOp);
+
+    expect(result).toEqual({
+      kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      message: ["message1", "message2"],
+    });
+  });
+
+  it("should convert SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE operation correctly", () => {
+    const smartRollupExecuteOutboxMessageOp: PartialTezosSmartRollupExecuteOutboxMessageOperation = {
+      kind: TezosOperationType.SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      rollup: "sr1VSU...Yt8G",
+      cemented_commitment: "commitment_hash",
+      output_proof: "proof_data",
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(smartRollupExecuteOutboxMessageOp);
+
+    expect(result).toEqual({
+      kind: OpKind.SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      rollup: "sr1VSU...Yt8G",
+      cementedCommitment: "commitment_hash",
+      outputProof: "proof_data",
+    });
+  });
+
+  it("should convert SMART_ROLLUP_ORIGINATE operation correctly", () => {
+    const smartRollupOriginateOp: PartialTezosSmartRollupOriginateOperation = {
+      kind: TezosOperationType.SMART_ROLLUP_ORIGINATE,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      pvm_kind: PvmKind.WASM2,
+      kernel: "kernel_data",
+      parameters_ty: { prim: 'int' } 
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(smartRollupOriginateOp);
+
+    expect(result).toEqual({
+      kind: OpKind.SMART_ROLLUP_ORIGINATE,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      pvmKind: PvmKind.WASM2,
+      kernel: "kernel_data",
+      parametersType: { prim: 'int' } 
+    });
+  });
+
+  it("should convert TRANSFER_TICKET operation correctly", () => {
+    const transferTicketOp: PartialTezosTransferTicketOperation = {
+      kind: TezosOperationType.TRANSFER_TICKET,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      ticket_contents: { prim: 'int' } ,
+      ticket_ty: { prim: 'int' } ,
+      ticket_ticketer: "tz1VSU...Yt8G",
+      ticket_amount: "100",
+      destination: "tz1VSU...Yt8G",
+      entrypoint: "default",
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(transferTicketOp);
+
+    expect(result).toEqual({
+      kind: OpKind.TRANSFER_TICKET,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      ticketContents: { prim: 'int' } ,
+      ticketTy: { prim: 'int' } ,
+      ticketTicketer: "tz1VSU...Yt8G",
+      ticketAmount: 100,
+      destination: "tz1VSU...Yt8G",
+      entrypoint: "default",
+    });
+  });
+
+  it("should convert UPDATE_CONSENSUS_KEY operation correctly", () => {
+    const updateConsensusKeyOp: PartialTezosUpdateConsensusKeyOperation = {
+      kind: TezosOperationType.UPDATE_CONSENSUS_KEY,
+      source: "tz1VSU...Yt8G",
+      fee: "1000",
+      gas_limit: "2000",
+      storage_limit: "0",
+      pk: "public_key_data",
+    };
+
+    const result: PartialParamsWithKind = convertToPartialParamsWithKind(updateConsensusKeyOp);
+
+    expect(result).toEqual({
+      kind: OpKind.UPDATE_CONSENSUS_KEY,
+      source: "tz1VSU...Yt8G",
+      fee: 1000,
+      gasLimit: 2000,
+      storageLimit: 0,
+      pk: "public_key_data",
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the integration of the Taquito library into the Tezos-Connect project. The changes include:
- importing types and functions from `@taquito/taquito`.
- Implementing the `convertToPartialParamsWithKind` and covering it with unit tests in `test/unit/convertToPartialParamsWithKind.test.ts`.  The conversion is done for all Taquito types in `ParamsWithKind`. These are types which can be passed to Taquito operation request.

Now, tezos-connect has all necessary types to be used in dapp-wallet interface and allows easy conversion from Beacon to Taquito types.